### PR TITLE
[INS-66] Bump lodash from 4.17.21 to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "long": {
       "version": "4.0.0",


### PR DESCRIPTION
## Summary

Security patch for the transitive `lodash` dependency (pulled via `ts-proto` -> `ts-poet`, which requires `lodash ^4.17.15`). Patched the resolution directly in `package-lock.json`, preserving `lockfileVersion: 1`.

Source: [Security patch tracking sheet](https://docs.google.com/spreadsheets/d/1yLFeSKRnToncdei6TCf-YPGt5PsdA4-_OPapxWYXCHM/edit?gid=0#gid=0)

The scanner recommended `4.18.0`, but that release is **deprecated on npm** ("Bad release. Please use lodash@4.17.21 instead."), so this uses the non-deprecated successor **`4.18.1`** (current `latest`, published the following day), which also satisfies the `^4.17.15` range.

## Test plan

- [x] `npm ci` installs cleanly and resolves `lodash@4.18.1` with no deprecation warning (verified locally, node 20.20.2)
- [x] Integrity hash independently verified against the published tarball